### PR TITLE
docs(getting-started): deno.land/x is deprecated

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -20,9 +20,12 @@ yarn add youtubei.js@latest
 
 # Git (edge version)
 npm install github:LuanRT/YouTube.js
+
+# Deno
+deno add npm:youtubei.js@latest
 ```
 
-For Deno:
+Deno (deprecated):
 ```ts
 import { Innertube } from 'https://deno.land/x/youtubei/deno.ts';
 ```


### PR DESCRIPTION
Related: https://github.com/LuanRT/YouTube.js/pull/885